### PR TITLE
Fix two edge cases in AoC 2018 Day 17

### DIFF
--- a/TypeScript/src/2018/17.ts
+++ b/TypeScript/src/2018/17.ts
@@ -67,6 +67,8 @@ function hasWall(grid: string[][], [x, y]: number[], xOffset = 1) {
   while (true) {
     if (grid[y][currentX] === '.') return false;
     if (grid[y][currentX] === '#') return true;
+    if (!grid[y][currentX]) return false;
+
     currentX += xOffset;
   }
 }
@@ -78,7 +80,7 @@ function fillSide(grid: string[][], [x, y]: number[], xOffset = 1) {
   let currentX = x;
   while (true) {
     if (grid[y][currentX] === '#') return;
-    grid[y][currentX] = '~';
+    grid[y][currentX] = grid[y + 1][currentX] === '|' ? '|' : '~';
     currentX += xOffset;
   }
 }


### PR DESCRIPTION
Hey there! 👋  Thank you very much for publishing your solutions! 

I am currently going through AoC 2018 (!) and got really stuck on day 17 (the one with the water flowing down wells). I found [your solution on Reddit](https://www.reddit.com/r/adventofcode/comments/a6wpup/2018_day_17_solutions/ebypy8w/) and decided to give it a go (and massage it a bit so I understand it better). It worked perfectly for part 1, but I hit an incorrect answer on part 2, which surprised me.

After carefully going through the grid to find something that could have gone wrong, I noticed a case that your code did not handle (and I guess did not appear in your puzzle input). Consider the following section. On the left is the grid without water; in the middle is what your code generates, and on the right is what the expected result should be. As you can see, the small gap between the two wells end up being filled with resting water instead of falling water.

```
     RAW                ACTUAL             EXPECTED
......+.......      ......+.......      ......+.......
..............      ..|||||||||...      ..|||||||||...
...#######....      ..|#######|...      ..|#######|...
..............      ..|.......|...      ..|.......|...
..............      ..|...||||||||      ..|...||||||||
........#...#.      ||||||||#~~~#|      ||||||||#~~~#|
.#...#..#...#.      |#~~~#~~#~~~#|      |#~~~#||#~~~#|
.#...#..#...#.      |#~~~#~~#~~~#|      |#~~~#||#~~~#|
.#...#..#####.      |#~~~#~~#####|      |#~~~#||#####|
.#####........      |#####||.....|      |#####||.....|
..............      |.....||.....|      |.....||.....|
```

It took me a little while, but I think I figured out how to solve the problem. The `fillSide` function always fills in with resting water (`~`), regardless of whether that water is in suspension or not. I think by checking the row underneath it, we can switch between the two types of water and pick the right one.

```diff
const fillSide = (grid, [x, y], xOffset) => {
  let currentX = x
  while (true) {
    if (grid[y][currentX] === '#') return
-    grid[y][currentX] = '~'
+    grid[y][currentX] = grid[y + 1][currentX] === '|' ? '|' : '~'
    currentX += xOffset
  }
}
```

This did the trick for my input (also double checked the output myself just to make sure the problem no longer appeared). Additionally, I‘ve noticed that the `hasWall` function doesn’t have a check for reaching the end of the grid. I didn’t encounter that on my input, but I did when creating the reduced test case from above, so I thought I’d add it as well.

Feel free to close the PR if you don’t want to fix the code — I understand it’s a few years old. Cheers! :)
